### PR TITLE
Option to disable power cycle on initialisation

### DIFF
--- a/custom_components/sonyavr/config_flow.py
+++ b/custom_components/sonyavr/config_flow.py
@@ -13,12 +13,13 @@ from homeassistant.const import (
 from homeassistant.core import callback
 
 from homeassistant.helpers.selector import (
+    BooleanSelector,
     NumberSelector,
     NumberSelectorConfig,
     NumberSelectorMode,
 )
 
-from .const import DOMAIN, CONF_PING_INTERVAL, CONF_MAX_VOLUME
+from .const import DOMAIN, CONF_PING_INTERVAL, CONF_MAX_VOLUME, CONF_POWER_CYCLE_INIT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +46,7 @@ OPTIONS_SCHEMA = vol.Schema(
             ),
             vol.Coerce(int),
         ),
+        vol.Optional(CONF_POWER_CYCLE_INIT, default=True): BooleanSelector(),
     }
 )
 
@@ -117,6 +119,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_MAX_VOLUME: self.config_entry.options.get(CONF_MAX_VOLUME),
                     CONF_PING_INTERVAL: self.config_entry.options.get(
                         CONF_PING_INTERVAL, 60
+                    ),
+                    CONF_POWER_CYCLE_INIT: self.config_entry.options.get(
+                        CONF_POWER_CYCLE_INIT, True
                     ),
                 },
             ),

--- a/custom_components/sonyavr/const.py
+++ b/custom_components/sonyavr/const.py
@@ -2,6 +2,7 @@ SERVICE_UPDATE_STATE = "update_state"
 CONF_MANUAL = "manual"
 CONF_MAX_VOLUME = "max_volume"
 CONF_PING_INTERVAL = "ping_interval"
+CONF_POWER_CYCLE_INIT = "initialize_by_power_cycle"
 
 DOMAIN = "sonyavr"
 DEFAULT_NAME = "SONY AVR"

--- a/custom_components/sonyavr/media_player.py
+++ b/custom_components/sonyavr/media_player.py
@@ -5,7 +5,7 @@ import asyncio
 
 from .const import DOMAIN
 
-from .const import SERVICE_SEND_COMMAND, SERVICE_UPDATE_STATE
+from .const import SERVICE_SEND_COMMAND, SERVICE_UPDATE_STATE, CONF_POWER_CYCLE_INIT
 
 import voluptuous as vol
 
@@ -66,7 +66,7 @@ async def async_setup_entry(
 
     sonyavr = config["sonyavr"]
 
-    async_add_entities([SonyAVRDevice(sonyavr, hass)])
+    async_add_entities([SonyAVRDevice(sonyavr, hass, config_entry)])
 
     # Register entity services
     platform = entity_platform.async_get_current_platform()
@@ -85,9 +85,10 @@ async def async_setup_entry(
 class SonyAVRDevice(MediaPlayerEntity):
     # Representation of a Sony AVR
 
-    def __init__(self, device, hass):
+    def __init__(self, device, hass, config_entry):
         self._device = device
         self._hass = hass
+        self._config_entry = config_entry
         self._entity_id = "media_player.sonyavr"
         self._unique_id = "sonyavr_" + self._device.name.replace(" ", "_").replace(
             "-", "_"
@@ -109,15 +110,16 @@ class SonyAVRDevice(MediaPlayerEntity):
         if self._device.state_service.power is None:
             _LOGGER.debug("Power state is uninitialised, so initialising all states")
             _power_state = await self._device.async_get_power_state()
+            _power_cycle = self._config_entry.options.get(CONF_POWER_CYCLE_INIT, True)
 
             # Turn on and off to force the feedback
-            if not _power_state:
+            if not _power_state and _power_cycle:
                 _LOGGER.debug("_power_state is False, so turning on")
                 await self._device.async_turn_on()
                 await asyncio.sleep(20)
             await self._device.async_update_status()
             _LOGGER.debug("Device states initialised")
-            if not _power_state:
+            if not _power_state and _power_cycle:
                 await asyncio.sleep(1)
                 await self._device.async_turn_off()
 

--- a/custom_components/sonyavr/translations/en.json
+++ b/custom_components/sonyavr/translations/en.json
@@ -26,7 +26,8 @@
         "title": "AVR Configuration",
         "data": {
           "max_volume": "Maximum Allowed Volume",
-          "ping_interval": "Number of seconds between connectivity check pings.  0 to disable"
+          "ping_interval": "Number of seconds between connectivity check pings.  0 to disable",
+          "initialize_by_power_cycle": "Initialize by Power Cycle on HA Restart"
         },
         "description": "Configuration Options for AVR"
       }


### PR DESCRIPTION
Add a config option to disable the power cycle used to initialise state on HA restart.

When the receiver is off at startup, the integration turns it on, waits 20 seconds to collect state feedback, then turns it back off. This triggers any automations watching the receiver state.

New toggle in the options flow: Initialize by Power Cycle on HA Restart. Defaults to on so existing behaviour is unchanged.

Closes #33